### PR TITLE
Example uses SizedBox instead of Container. Updated text to follow suit.

### DIFF
--- a/src/development/ui/layout/index.md
+++ b/src/development/ui/layout/index.md
@@ -624,7 +624,7 @@ final [!leftColumn!] = Container(
 );
 ```
 
-The left column is placed in a `Container` to constrain its width.
+The left column is placed in a `SizedBox` to constrain its width.
 Finally, the UI is constructed with the entire row (containing the
 left column and the image) inside a `Card`.
 


### PR DESCRIPTION
_Description of what this PR is changing or adding, and why:_
The example has apparently been updated to use a `SizedBox` instead of a `Container` but the text has not been updated to reflect that. This fixes that.

_Issues fixed by this PR (if any):_

## Presubmit checklist
- [x] This PR doesn’t contain automatically generated corrections (Grammarly or similar).
- [x] This PR follows the [Google Developer Documentation Style Guidelines](https://developers.google.com/style) — for example, it doesn’t use _i.e._ or _e.g._, and it avoids _I_ and _we_ (first person).
- [x] This PR uses [semantic line breaks](https://github.com/dart-lang/site-shared/blob/master/doc/writing-for-dart-and-flutter-websites.md#semantic-line-breaks) of 80 characters or fewer.
